### PR TITLE
Zypper best practices for tumbleweed

### DIFF
--- a/package-managers/zypper.yaml
+++ b/package-managers/zypper.yaml
@@ -4,11 +4,11 @@ needsudo: true
 cmdautoremove: zypper
 cmdclean: zypper clean
 cmdinstall: zypper install
-cmdlist: zypper pa
+cmdlist: zypper pa --installed-only
 cmdpurge: zypper remove
 cmdremove: zypper remove
 cmdsearch: zypper search
 cmdshow: zypper info
-cmdupdate: zypper update
-cmdupgrade: zypper update
+cmdupdate: zypper dup
+cmdupgrade: zypper dup
 builtin: true


### PR DESCRIPTION
- `zypper pa` lists _all_ packages but the `apx <runtime>` helptext implies this should only list installed packages
- in tumbleweed we want to be running `zypper dup` instead of `zypper update` to catch non-upgrade package changes in the tumbleweed repos