### PR TITLE
feat: use latest opensuse leap

### DIFF
--- a/stacks/opensuse-leap-15.6.yaml
+++ b/stacks/opensuse-leap-15.6.yaml
@@ -1,5 +1,0 @@
-name: opensuse-leap-15.6
-base: registry.opensuse.org/opensuse/leap:15.6
-packages: []
-pkgmanager: zypper
-builtin: true

--- a/stacks/opensuse-leap.yaml
+++ b/stacks/opensuse-leap.yaml
@@ -1,0 +1,5 @@
+name: opensuse-leap
+base: registry.opensuse.org/opensuse/leap:latest
+packages: []
+pkgmanager: zypper
+builtin: true


### PR DESCRIPTION
Update the openSUSE Leap stack to use the `latest` tag, aligning with other fixed-release distros.